### PR TITLE
Add mock data feature

### DIFF
--- a/Startup.cs
+++ b/Startup.cs
@@ -26,10 +26,18 @@ namespace belong
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            // services.Add(new ServiceDescriptor(typeof(IHostRepository), new HostInMemoryRepository()));
-            services.AddDbContext<BelongDbContext>(options => options.UseSqlServer(Configuration.GetConnectionString("BelongDb")));
-            // services.AddScoped<IHostRepository, HostSqlRepository>();
-            services.AddScoped<IHostRepository, HostDapperRepository>();
+            var useMockData = Configuration.GetValue<bool>("UseMockData");
+
+            if (useMockData)
+            {
+                services.AddScoped<IHostRepository, HostInMemoryRepository>();
+            }
+            else
+            {
+                services.AddDbContext<BelongDbContext>(options => options.UseSqlServer(Configuration.GetConnectionString("BelongDb")));
+                services.AddScoped<IHostRepository, HostDapperRepository>();
+            }
+
             services.AddControllers();
         }
 

--- a/appsettings.json
+++ b/appsettings.json
@@ -9,5 +9,6 @@
   "AllowedHosts": "*",
   "ConnectionStrings": {
     "BelongDb": "Server=sequel.cmnemrz1mbor.us-west-1.rds.amazonaws.com;Database=belong;user id=admin;password=rdssqladmin"
-  }
+  },
+  "UseMockData": true
 }


### PR DESCRIPTION
Add a configuration setting to control the use of mock/sample data instead of SQL data.

* Add a new setting `UseMockData` in `appsettings.json` and set its value to `true` by default.
* Update `Startup.cs` to read the `UseMockData` setting and register the appropriate repository (`HostInMemoryRepository` or `HostDapperRepository`) based on its value.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/fcmendoza/belong/pull/2?shareId=ccb831d2-c85e-45d2-80da-337f4a2dc070).